### PR TITLE
Suggested changes

### DIFF
--- a/Sources/MongoMobile/MongoMobile.swift
+++ b/Sources/MongoMobile/MongoMobile.swift
@@ -1,6 +1,5 @@
 import Foundation
 import mongo_embedded
-import MongoSwift
 
 /// Settings for constructing a `MongoClient`
 public struct MongoClientSettings {

--- a/Sources/MongoMobile/MongoMobile.swift
+++ b/Sources/MongoMobile/MongoMobile.swift
@@ -1,124 +1,138 @@
+import Foundation
 import mongo_embedded
-
-let MONGO_EMBEDDED_V1_ERROR_EXCEPTION = 2;
+import MongoSwift
 
 /// Settings for constructing a `MongoClient`
 public struct MongoClientSettings {
-  /// the database path to use
-  public let dbPath: String
+    /// the database path to use
+    public let dbPath: String
 
-  /// public member-wise initializer
-  public init(dbPath: String) {
-    self.dbPath = dbPath
-  }
+    /// public member-wise initializer
+    public init(dbPath: String) {
+        self.dbPath = dbPath
+    }
 }
 
-public enum MongoMobileError: Error {
+/// Errors associated with `MongoMobile`.
+public enum MongoMobileError: LocalizedError {
     case invalidClient()
     case invalidInstance(message: String)
     case invalidLibrary()
     case instanceDropError(message: String)
     case cleanupError(message: String)
+
+    /// a string to be printed out when the error is thrown
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidInstance(message),
+            let .instanceDropError(message),
+            let .cleanupError(message):
+            return message
+        default:
+            return nil
+        }
+    }
 }
 
+/// Prints a log statement in the format `[component] message`.
 private func mongo_mobile_log_callback(userDataPtr: UnsafeMutableRawPointer?,
                                        messagePtr: UnsafePointer<Int8>?,
                                        componentPtr: UnsafePointer<Int8>?,
                                        contextPtr: UnsafePointer<Int8>?,
-                                       severityPtr: Int32)
-{
-    let message = String(cString: messagePtr!)
-    let component = String(cString: componentPtr!)
+                                       severityPtr: Int32) {
+    let message = messagePtr ? String(cString: messagePtr!) : ""
+    let component = componentPtr ? String(cString: componentPtr!) : ""
     print("[\(component)] \(message)")
 }
 
+/// Given an `OpaquePointer` to a `mongo_embedded_v1_status`, get the status's explanation.
+private func getStatusExplanation(_ status: OpaquePointer) -> String {
+    return String(cString: mongo_embedded_v1_status_get_explanation(status))
+}
+
+/// A class containing static methods for working with MongoMobile.
 public class MongoMobile {
-  private static var libraryInstance: OpaquePointer?
-  private static var embeddedInstances = [String: OpaquePointer]()
+    private static var libraryInstance: OpaquePointer?
+    private static var embeddedInstances = [String: OpaquePointer]()
 
-  /**
-   * Perform required operations to initialize the embedded server.
-   */
-  public static func initialize() throws {
-    // NOTE: remove once MongoSwift is handling this
-    mongoc_init()
+    /**
+     * Perform required operations to initialize the embedded server.
+     */
+    public static func initialize() throws {
+        MongoSwift.initialize()
 
-    let status = mongo_embedded_v1_status_create()
-    var initParams = mongo_embedded_v1_init_params()
-    initParams.log_callback = mongo_mobile_log_callback
-    initParams.log_flags = 4 // LIBMONGODB_CAPI_LOG_CALLBACK
+        let status = mongo_embedded_v1_status_create()
+        var initParams = mongo_embedded_v1_init_params()
+        initParams.log_callback = mongo_mobile_log_callback
+        initParams.log_flags = MONGO_EMBEDDED_V1_LOG_CALLBACK
 
-    guard let instance = mongo_embedded_v1_lib_init(&initParams, status) else {
-        throw MongoMobileError.invalidInstance(message:
-                String(cString: mongo_embedded_v1_status_get_explanation(status)))
+        guard let instance = mongo_embedded_v1_lib_init(&initParams, status) else {
+            throw MongoMobileError.invalidInstance(message: getStatusExplanation(status))
+        }
+
+        libraryInstance = instance
     }
 
-    libraryInstance = instance
-  }
+    /**
+     * Perform required operations to clean up the embedded server.
+     */
+    public static func close() throws {
+        let status = mongo_embedded_v1_status_create()
+        for (_, instance) in embeddedInstances {
+            let result = mongo_embedded_v1_instance_destroy(instance, status)
+            if result == MONGO_EMBEDDED_V1_ERROR_EXCEPTION {
+                throw MongoMobileError.instanceDropError(message: getStatusExplanation(status))
+            }
+        }
 
-  /**
-   * Perform required operations to cleanup the embedded server.
-   */
-  public static func close() throws {
-    let status = mongo_embedded_v1_status_create()
-    for (_, instance) in embeddedInstances {
-        let result = mongo_embedded_v1_instance_destroy(instance, status)
+        let result = mongo_embedded_v1_lib_fini(libraryInstance, status)
         if result == MONGO_EMBEDDED_V1_ERROR_EXCEPTION {
-            throw MongoMobileError.instanceDropError(message:
-                String(cString: mongo_embedded_v1_status_get_explanation(status)))
+            throw MongoMobileError.cleanupError(message: getStatusExplanation(status))
         }
+
+        MongoSwift.cleanup()
     }
 
-    let result = mongo_embedded_v1_lib_fini(libraryInstance, status)
-    if result == MONGO_EMBEDDED_V1_ERROR_EXCEPTION {
-        throw MongoMobileError.cleanupError(message:
-            String(cString: mongo_embedded_v1_status_get_explanation(status)))
-    }
-
-    // NOTE: remove once MongoSwift is handling this
-    mongoc_cleanup()
-  }
-
-  /**
-   * Create a new `MongoClient` for the database indicated by `dbPath` in
-   * the passed in settings.
-   *
-   * - Parameters:
-   *   - settings: required settings for client creation
-   *
-   * - Returns: a new `MongoClient`
-   */
-  public static func create(_ settings: MongoClientSettings) throws -> MongoClient {
-    let status = mongo_embedded_v1_status_create()
-    var instance: OpaquePointer
-    if let cachedInstance = embeddedInstances[settings.dbPath] {
-        instance = cachedInstance
-    } else {
-        let configuration = [
-            "storage": [
-                "dbPath": settings.dbPath
+    /**
+     * Create a new `MongoClient` for the database indicated by `dbPath` in
+     * the passed in settings.
+     *
+     * - Parameters:
+     *   - settings: required settings for client creation
+     *
+     * - Returns: a new `MongoClient`
+     */
+    public static func create(_ settings: MongoClientSettings) throws -> MongoClient {
+        let status = mongo_embedded_v1_status_create()
+        var instance: OpaquePointer?
+        if let cachedInstance = embeddedInstances[settings.dbPath] {
+            instance = cachedInstance
+        } else {
+            // get the configuration as a JSON string
+            let configuration = [
+                "storage": [
+                    "dbPath": settings.dbPath
+                ]
             ]
-        ]
+            let configurationData = try JSONSerialization.data(withJSONObject: configuration)
+            let configurationString = String(data: configurationData, encoding: .utf8)
 
-        let configurationData = try JSONSerialization.data(withJSONObject: configuration)
-        let configurationString = String(data: configurationData, encoding: .utf8)
-        guard let library = libraryInstance else {
-            throw MongoMobileError.invalidLibrary()
+            guard let library = libraryInstance else {
+                throw MongoMobileError.invalidLibrary()
+            }
+
+            guard let capiInstance = mongo_embedded_v1_instance_create(library, configurationString, status) else {
+                throw MongoMobileError.invalidInstance(message: getStatusExplanation(status))
+            }
+
+            instance = capiInstance
+            embeddedInstances[settings.dbPath] = instance
         }
 
-        guard let capiInstance = mongo_embedded_v1_instance_create(library, configurationString, status) else {
-            throw MongoMobileError.invalidInstance(message:
-                String(cString: mongo_embedded_v1_status_get_explanation(status)))
+        guard let capiClient = mongo_embedded_v1_mongoc_client_create(instance) else {
+            throw MongoMobileError.invalidClient()
         }
 
-        instance = capiInstance
-        embeddedInstances[settings.dbPath] = instance
+        return MongoClient(fromPointer: capiClient)
     }
-
-    guard let capiClient = mongo_embedded_v1_mongoc_client_create(instance) else {
-        throw MongoMobileError.invalidClient()
-    }
-
-    return MongoClient(fromPointer: capiClient)
-  }
 }

--- a/Sources/MongoMobile/MongoMobile.swift
+++ b/Sources/MongoMobile/MongoMobile.swift
@@ -40,13 +40,13 @@ private func mongo_mobile_log_callback(userDataPtr: UnsafeMutableRawPointer?,
                                        componentPtr: UnsafePointer<Int8>?,
                                        contextPtr: UnsafePointer<Int8>?,
                                        severityPtr: Int32) {
-    let message = messagePtr ? String(cString: messagePtr!) : ""
-    let component = componentPtr ? String(cString: componentPtr!) : ""
+    let message = messagePtr != nil ? String(cString: messagePtr!) : ""
+    let component = componentPtr != nil ? String(cString: componentPtr!) : ""
     print("[\(component)] \(message)")
 }
 
 /// Given an `OpaquePointer` to a `mongo_embedded_v1_status`, get the status's explanation.
-private func getStatusExplanation(_ status: OpaquePointer) -> String {
+private func getStatusExplanation(_ status: OpaquePointer?) -> String {
     return String(cString: mongo_embedded_v1_status_get_explanation(status))
 }
 
@@ -64,7 +64,7 @@ public class MongoMobile {
         let status = mongo_embedded_v1_status_create()
         var initParams = mongo_embedded_v1_init_params()
         initParams.log_callback = mongo_mobile_log_callback
-        initParams.log_flags = MONGO_EMBEDDED_V1_LOG_CALLBACK
+        initParams.log_flags = UInt64(MONGO_EMBEDDED_V1_LOG_CALLBACK.rawValue)
 
         guard let instance = mongo_embedded_v1_lib_init(&initParams, status) else {
             throw MongoMobileError.invalidInstance(message: getStatusExplanation(status))
@@ -80,13 +80,13 @@ public class MongoMobile {
         let status = mongo_embedded_v1_status_create()
         for (_, instance) in embeddedInstances {
             let result = mongo_embedded_v1_instance_destroy(instance, status)
-            if result == MONGO_EMBEDDED_V1_ERROR_EXCEPTION {
+            if result == MONGO_EMBEDDED_V1_ERROR_EXCEPTION.rawValue {
                 throw MongoMobileError.instanceDropError(message: getStatusExplanation(status))
             }
         }
 
         let result = mongo_embedded_v1_lib_fini(libraryInstance, status)
-        if result == MONGO_EMBEDDED_V1_ERROR_EXCEPTION {
+        if result == MONGO_EMBEDDED_V1_ERROR_EXCEPTION.rawValue {
             throw MongoMobileError.cleanupError(message: getStatusExplanation(status))
         }
 

--- a/Tests/MongoMobileTests/MongoMobileTests.swift
+++ b/Tests/MongoMobileTests/MongoMobileTests.swift
@@ -9,11 +9,11 @@ final class MongoMobileTests: XCTestCase {
     }
 
     func testMongoMobile() throws {
-      let client = MongoMobile.create(settings: MongoClientSettings [ dbPath: "test-path" ])
-      let coll = try client.db("test").collection("foo")
-      let insertResult = try coll.insertOne([ "test": 42 ])
-      let findResult = try coll.find([ "_id": insertResult!.insertedId ])
-      let docs = Array(findResult)
-      XCTAssertEqual(docs[0]["test"] as? Int, 42)
+        let client = MongoMobile.create(settings: MongoClientSettings(dbPath: "test-path"))
+        let coll = try client.db("test").collection("foo")
+        let insertResult = try coll.insertOne([ "test": 42 ])
+        let findResult = try coll.find([ "_id": insertResult!.insertedId ])
+        let docs = Array(findResult)
+        XCTAssertEqual(docs[0]["test"] as? Int, 42)
     }
 }


### PR DESCRIPTION
- 2->4 spaces since we're using 4 in the driver and the sample app
- use the new MongoSwift `initialize` and `cleanup` functions 
- make error messages actually print out
- helper for getting status explanation
- use mongo embedded constants directly 
- get rid of force unwraps 
- `import Foundation` for sake of clarity (it won't build in TestMongoMobile if we explicitly `import MongoSwift` though) 

the sample app builds and seems to work ok with these changes.