### PR TITLE
SWIFT-296: allow sequential access to embedded server

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,55 @@
+disabled_rules:
+  - file_length
+  - function_body_length
+  - identifier_name
+  - todo
+  - type_body_length
+  - type_name
+
+opt_in_rules:
+  - array_init
+  - collection_alignment
+  - contains_over_first_not_nil
+  - closure_end_indentation
+  - closure_spacing
+  - conditional_returns_on_newline
+  - empty_count
+  - empty_string
+  - explicit_acl
+  - explicit_init
+  - explicit_self
+  - fatal_error_message
+  - first_where
+  - force_unwrapping
+  - implicit_return
+  - missing_docs
+  - modifier_order
+  - multiline_arguments
+  - multiline_function_chains
+  - multiline_literal_brackets
+  - multiline_parameters
+  - operator_usage_whitespace
+  - pattern_matching_keywords
+  - redundant_nil_coalescing
+  - redundant_type_annotation
+  - sorted_first_last
+  - sorted_imports
+  - trailing_closure
+  - unneeded_parentheses_in_closure_argument
+  - unused_import
+  - unused_private_declaration
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace_closing_braces
+  - vertical_whitespace_opening_braces
+
+excluded:
+  - build
+  - .build
+  - docs
+  - Examples/*/build
+  - Examples/*/.build
+  - Sources/libbson
+  - Sources/libmongoc
+  - Package.swift
+  - Package@swift-4.2.swift
+  - Examples/*/Package.swift

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,11 @@ before_install:
   - gem install cocoapods --pre
   - pod repo update
 
+before_script:
+  - wget https://github.com/realm/SwiftLint/releases/download/0.29.3/portable_swiftlint.zip -O /tmp/swiftlint.zip
+  - unzip /tmp/swiftlint.zip -d ${PWD}/bin
+  - export PATH=$PATH:${PWD}/bin
+
 script:
+  - swiftlint --strict
   - pod lib lint --allow-warnings --fail-fast --verbose --platforms=ios

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: swift
+osx_image: xcode9.4
+
+before_install:
+  - gem install cocoapods --pre
+  - pod repo update
+
+script:
+  - pod lib lint --allow-warnings --fail-fast --verbose --platforms=ios

--- a/MongoMobile.podspec
+++ b/MongoMobile.podspec
@@ -17,7 +17,11 @@ Pod::Spec.new do |spec|
   spec.requires_arc = true
   spec.source_files = ["Sources/MongoMobile/**/*.swift"]
 
-  spec.dependency 'MongoSwift', '~> 0.0.7'
-  spec.dependency 'mongoc_embedded', '~> 4.0.4'
-  spec.dependency 'mongo_embedded', '~> 4.0.4'
+  spec.dependency "MongoSwift", "~> 0.0.7"
+  spec.dependency "mongoc_embedded", "~> 4.0.4"
+  spec.dependency "mongo_embedded", "~> 4.0.4"
+
+  spec.test_spec "Tests" do |test_spec|
+    test_spec.source_files = "Tests/MongoMobileTests/*.swift"
+  end
 end

--- a/Sources/MongoMobile/MongoMobile.swift
+++ b/Sources/MongoMobile/MongoMobile.swift
@@ -42,8 +42,7 @@ public struct MongoEmbeddedV1Error: LocalizedError {
         return "\(error): \(statusMessage)"
     }
 
-    public init(_ error: mongo_embedded_v1_error,
-                statusMessage: String) {
+    internal init(_ error: mongo_embedded_v1_error, statusMessage: String) {
         self.statusMessage = statusMessage
         self.error = error
     }

--- a/Sources/MongoMobile/MongoMobile.swift
+++ b/Sources/MongoMobile/MongoMobile.swift
@@ -134,9 +134,9 @@ public class MongoMobile {
         if let cachedInstance = embeddedInstances[settings.dbPath] {
             instance = cachedInstance
         } else {
-            // NOTE: This is hack can be removed once SERVER-38943 is resolved. Also note
+            // NOTE: This hack can be removed once SERVER-38943 is resolved. Also note
             //       that the destroy code is not refactored into a common function because
-            //       we should be removing this code in the future.
+            //       we should be removing this code in the near future.
             if embeddedInstances.count > 0 {
                 self.embeddedClients.forEach { ref in ref.reference?.close() }
                 embeddedClients.removeAll()

--- a/Sources/MongoMobile/MongoMobile.swift
+++ b/Sources/MongoMobile/MongoMobile.swift
@@ -1,7 +1,7 @@
 import Foundation
-import MongoSwift
 import mongo_embedded
 import mongoc_embedded
+import MongoSwift
 
 /// Settings for constructing a `MongoClient`
 public struct MongoClientSettings {
@@ -42,8 +42,8 @@ public struct MongoEmbeddedV1Error: LocalizedError {
         return "\(error): \(statusMessage)"
     }
 
-    init(_ error: mongo_embedded_v1_error,
-         statusMessage: String) {
+    public init(_ error: mongo_embedded_v1_error,
+                statusMessage: String) {
         self.statusMessage = statusMessage
         self.error = error
     }
@@ -55,7 +55,9 @@ private func mongo_mobile_log_callback(userDataPtr: UnsafeMutableRawPointer?,
                                        componentPtr: UnsafePointer<Int8>?,
                                        contextPtr: UnsafePointer<Int8>?,
                                        severityPtr: Int32) {
+    // swiftlint:disable:next force_unwrapping - always returns a value if not null
     let message = messagePtr != nil ? String(cString: messagePtr!) : ""
+    // swiftlint:disable:next force_unwrapping - always returns a value if not null
     let component = componentPtr != nil ? String(cString: componentPtr!) : ""
     print("[\(component)] \(message)")
 }
@@ -96,7 +98,7 @@ public class MongoMobile {
             throw MongoMobileError.invalidInstance(message: getStatusExplanation(status))
         }
 
-        libraryInstance = instance
+        self.libraryInstance = instance
     }
 
     /**
@@ -104,14 +106,14 @@ public class MongoMobile {
      */
     public static func close() throws {
         self.embeddedClients.forEach { ref in ref.reference?.close() }
-        embeddedClients.removeAll()
+        self.embeddedClients.removeAll()
 
-        for (_, instance) in embeddedInstances { try destroyInstance(instance) }
-        embeddedInstances.removeAll()
+        for (_, instance) in self.embeddedInstances { try destroyInstance(instance) }
+        self.embeddedInstances.removeAll()
 
         let status = mongo_embedded_v1_status_create()
-        let result = mongo_embedded_v1_error(mongo_embedded_v1_lib_fini(libraryInstance, status))
-        if result != MONGO_EMBEDDED_V1_SUCCESS {
+        let result = mongo_embedded_v1_error(mongo_embedded_v1_lib_fini(self.libraryInstance, status))
+        guard result == MONGO_EMBEDDED_V1_SUCCESS else {
             throw MongoEmbeddedV1Error(result,
                                        statusMessage: getStatusExplanation(status))
         }
@@ -131,18 +133,18 @@ public class MongoMobile {
     public static func create(_ settings: MongoClientSettings) throws -> MongoClient {
         let status = mongo_embedded_v1_status_create()
         var instance: OpaquePointer?
-        if let cachedInstance = embeddedInstances[settings.dbPath] {
+        if let cachedInstance = self.embeddedInstances[settings.dbPath] {
             instance = cachedInstance
         } else {
             // NOTE: This hack can be removed once SERVER-38943 is resolved. Also note
             //       that the destroy code is not refactored into a common function because
             //       we should be removing this code in the near future.
-            if embeddedInstances.count > 0 {
+            if !self.embeddedInstances.isEmpty {
                 self.embeddedClients.forEach { ref in ref.reference?.close() }
-                embeddedClients.removeAll()
+                self.embeddedClients.removeAll()
 
-                for (_, instance) in embeddedInstances { try destroyInstance(instance) }
-                embeddedInstances.removeAll()
+                for (_, instance) in self.embeddedInstances { try destroyInstance(instance) }
+                self.embeddedInstances.removeAll()
             }
 
             // get the configuration as a JSON string
@@ -154,7 +156,7 @@ public class MongoMobile {
             let configurationData = try JSONSerialization.data(withJSONObject: configuration)
             let configurationString = String(data: configurationData, encoding: .utf8)
 
-            guard let library = libraryInstance else {
+            guard let library = self.libraryInstance else {
                 throw MongoMobileError.invalidLibrary()
             }
 
@@ -163,7 +165,7 @@ public class MongoMobile {
             }
 
             instance = capiInstance
-            embeddedInstances[settings.dbPath] = instance
+            self.embeddedInstances[settings.dbPath] = instance
         }
 
         guard let capiClient = mongoc_embedded_v1_client_create(instance) else {
@@ -175,11 +177,10 @@ public class MongoMobile {
         return client
     }
 
-
     private static func destroyInstance(_ instance: OpaquePointer) throws {
         let status = mongo_embedded_v1_status_create()
         let result = mongo_embedded_v1_error(mongo_embedded_v1_instance_destroy(instance, status))
-        if result != MONGO_EMBEDDED_V1_SUCCESS {
+        guard result == MONGO_EMBEDDED_V1_SUCCESS else {
             throw MongoEmbeddedV1Error(result, statusMessage: getStatusExplanation(status))
         }
     }

--- a/Tests/MongoMobileTests/MongoMobileTests.swift
+++ b/Tests/MongoMobileTests/MongoMobileTests.swift
@@ -1,10 +1,10 @@
-import XCTest
 import MongoSwift
+import XCTest
 
 @testable import MongoMobile
 
-final class MongoMobileTests: XCTestCase {
-    static var allTests: [(String, (MongoMobileTests) -> () throws -> Void)] {
+public final class MongoMobileTests: XCTestCase {
+    public static var allTests: [(String, (MongoMobileTests) -> () throws -> Void)] {
         return [
             ("testMongoMobileBasic", testMongoMobileBasic),
             ("testSequentialAccess", testSequentialAccess)
@@ -14,63 +14,52 @@ final class MongoMobileTests: XCTestCase {
     // NOTE: These only works because we have one test suite. These method are called
     //       before/after all tests _per_ test suite. Will not work if another suite
     //       is added.
-    override class func setUp() {
+    override public class func setUp() {
         super.setUp()
         try? MongoMobile.initialize()
     }
 
-    override class func tearDown() {
+    override public class func tearDown() {
         super.tearDown()
         try? MongoMobile.close()
     }
 
-    func createAndCleanTemporaryPath(at path: String) throws -> URL {
+    public func createAndCleanTemporaryPath(at path: String) throws -> URL {
         let supportPath = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
         let databasePath = supportPath.appendingPathComponent(path)
 
-        do {
-            try FileManager.default.removeItem(at: databasePath)
-        } catch {}
-
-        do {
-            try FileManager.default.createDirectory(at: databasePath, withIntermediateDirectories: false)
-        } catch {}
-
+        try? FileManager.default.removeItem(at: databasePath)
+        try? FileManager.default.createDirectory(at: databasePath, withIntermediateDirectories: false)
         return databasePath
     }
 
-    func testMongoMobileBasic() throws {
-        let databasePath = try createAndCleanTemporaryPath(at: "test-mongo-mobile")
-        let settings = MongoClientSettings(dbPath: databasePath.path)
-        let client = try MongoMobile.create(settings)
-
-        // execute the test
+    public func runBasicInsertFindTest(on client: MongoClient) throws {
         let coll = try client.db("test").collection("foo")
         let insertResult = try coll.insertOne([ "test": 42 ])
+        // swiftlint:disable:next force_unwrapping - always returns a value if succeeded
         let findResult = try coll.find([ "_id": insertResult!.insertedId ])
         let docs = Array(findResult)
         XCTAssertEqual(docs[0]["test"] as? Int, 42)
     }
 
-    func testSequentialAccess() throws {
-        func runTest(on client: MongoClient) throws {
-            let coll = try client.db("test").collection("foo")
-            let insertResult = try coll.insertOne([ "test": 42 ])
-            let findResult = try coll.find([ "_id": insertResult!.insertedId ])
-            let docs = Array(findResult)
-            XCTAssertEqual(docs[0]["test"] as? Int, 42)
-        }
+    public func testMongoMobileBasic() throws {
+        let databasePath = try createAndCleanTemporaryPath(at: "test-mongo-mobile")
+        let settings = MongoClientSettings(dbPath: databasePath.path)
+        let client = try MongoMobile.create(settings)
+        try runBasicInsertFindTest(on: client)
+    }
 
+    public func testSequentialAccess() throws {
         let databasePathA = try createAndCleanTemporaryPath(at: "embedded-app-a")
         let clientA = try MongoMobile.create(MongoClientSettings(dbPath: databasePathA.path))
-        try runTest(on: clientA)
+        try runBasicInsertFindTest(on: clientA)
 
         let databasePathB = try createAndCleanTemporaryPath(at: "embedded-app-b")
         let clientB = try MongoMobile.create(MongoClientSettings(dbPath: databasePathB.path))
-        try runTest(on: clientB)
+        try runBasicInsertFindTest(on: clientB)
         // TODO: verify that clientA is closed when SWIFT-323 is completed
 
         let clientA2 = try MongoMobile.create(MongoClientSettings(dbPath: databasePathA.path))
-        try runTest(on: clientA2)
+        try runBasicInsertFindTest(on: clientA2)
     }
 }

--- a/Tests/MongoMobileTests/MongoMobileTests.swift
+++ b/Tests/MongoMobileTests/MongoMobileTests.swift
@@ -68,7 +68,7 @@ final class MongoMobileTests: XCTestCase {
         let databasePathB = try createAndCleanTemporaryPath(at: "embedded-app-b")
         let clientB = try MongoMobile.create(MongoClientSettings(dbPath: databasePathB.path))
         try runTest(on: clientB)
-        // TODO: verify that clientA is closed, etc
+        // TODO: verify that clientA is closed when SWIFT-323 is completed
 
         let clientA2 = try MongoMobile.create(MongoClientSettings(dbPath: databasePathA.path))
         try runTest(on: clientA2)

--- a/Tests/MongoMobileTests/MongoMobileTests.swift
+++ b/Tests/MongoMobileTests/MongoMobileTests.swift
@@ -2,14 +2,34 @@
 import XCTest
 
 final class MongoMobileTests: XCTestCase {
-    static var allTests: [(String, (ClientTests) -> () throws -> Void)] {
+    static var allTests: [(String, (MongoMobileTests) -> () throws -> Void)] {
         return [
             ("testMongoMobile", testMongoMobile)
         ]
     }
 
     func testMongoMobile() throws {
-        let client = MongoMobile.create(settings: MongoClientSettings(dbPath: "test-path"))
+        try MongoMobile.initialize()
+        defer {
+            try? MongoMobile.close()
+        }
+
+        // setup database
+        let documentPath = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let databasePath = documentPath.appendingPathComponent("test-mongo-mobile")
+
+        do {
+            try FileManager.default.removeItem(at: databasePath)
+        } catch {}
+
+        do {
+            try FileManager.default.createDirectory(at: databasePath, withIntermediateDirectories: false)
+        } catch {}
+
+        let settings = MongoClientSettings(dbPath: databasePath.path)
+        let client = try MongoMobile.create(settings)
+
+        // execute the test
         let coll = try client.db("test").collection("foo")
         let insertResult = try coll.insertOne([ "test": 42 ])
         let findResult = try coll.find([ "_id": insertResult!.insertedId ])


### PR DESCRIPTION
This implements the changes we discussed in the meeting last week, allowing sequential access to embedded instances. The changes should be relatively uncontroversial, and there are a few extra commits here just to get testing with cocoapods working as expected. 

/cc @patrickfreed (you're not in the `drivers-team` group! please make a MANA request for this or reach out to me on Monday and we can figure this out)