### PR TITLE
SWIFT-361 Improve error reporting in mobile library

### DIFF
--- a/Sources/MongoMobile/MongoMobile.swift
+++ b/Sources/MongoMobile/MongoMobile.swift
@@ -40,10 +40,10 @@ public enum MongoMobileError: LocalizedError {
     }
 }
 
-internal typealias mongo_embedded_v1_status_t = OpaquePointer
+internal typealias mongo_embedded_v1_status = OpaquePointer
 
 /// Given a `mongo_embedded_v1_status`, get an appropriate `MongoMobileError`.
-internal func parseMongoEmbeddedV1Status(_ status: mongo_embedded_v1_status_t?) -> MongoMobileError {
+internal func parseMongoEmbeddedV1Status(_ status: mongo_embedded_v1_status?) -> MongoMobileError {
     let error = mongo_embedded_v1_error(rawValue: mongo_embedded_v1_status_get_error(status))
 
     switch error {
@@ -57,12 +57,12 @@ internal func parseMongoEmbeddedV1Status(_ status: mongo_embedded_v1_status_t?) 
 }
 
 /// Given a `mongo_embedded_v1_status`, get the status's explanation.
-private func getStatusExplanation(_ status: mongo_embedded_v1_status_t?) -> String {
+private func getStatusExplanation(_ status: mongo_embedded_v1_status?) -> String {
     return String(cString: mongo_embedded_v1_status_get_explanation(status))
 }
 
 /// Given a `mongo_embedded_v1_status`, get the status's error code.
-private func getStatusCode(_ status: mongo_embedded_v1_status_t?) -> ServerErrorCode {
+private func getStatusCode(_ status: mongo_embedded_v1_status?) -> ServerErrorCode {
     return ServerErrorCode(mongo_embedded_v1_status_get_code(status))
 }
 

--- a/Sources/MongoMobile/MongoMobile.swift
+++ b/Sources/MongoMobile/MongoMobile.swift
@@ -33,7 +33,6 @@ public enum MongoMobileError: LocalizedError {
     /// Thrown when MongoMobile is incorrectly used.
     case logicError(message: String)
 
-
     /// a string to be printed out when the error is thrown
     public var errorDescription: String? {
         switch self {

--- a/Sources/MongoMobile/MongoMobile.swift
+++ b/Sources/MongoMobile/MongoMobile.swift
@@ -135,8 +135,13 @@ public class MongoMobile {
      *
      * - Throws:
      *   - `MongoMobileError.embeddedMongoError` if an error occurs while de-initializing the embedded server.
+     *   - `MongoMobileError.logicError` if MongoMobile has not been initialized yet.
      */
     public static func close() throws {
+        guard self.libraryInstance != nil else {
+            throw MongoMobileError.logicError(message: "MongoMobile must be initialized before closing")
+        }
+
         self.embeddedClients.forEach { ref in ref.reference?.close() }
         self.embeddedClients.removeAll()
 


### PR DESCRIPTION
[SWIFT-361](https://jira.mongodb.org/browse/SWIFT-361)

The new error cases are as follows:
- `.logicError(message)`: thrown when MongoMobile is used incorrectly (e.g. calling `close` without calling `initialize`)
- `.embeddedMongoError(code, message)`: thrown when the embedded server returns an error
    - I know embedded mongo will throw these errors based on inspecting its source and from reading the docs, but I'm not sure under what exact circumstances they'll occur.
- `.internalError(message)`: any error thrown by embedded mongo library that isn't tied to a server error or any error we encounter at the swift level (e.g. client creation failed)

These closely mirror the errors thrown from the driver, but they don't have separate enum types like the driver because there's so few cases. I wasn't able to add any tests because I'm not exactly sure how to replicate any errors besides logic errors. That said, if the embedded mongo documentation is correct (i.e. the docstrings `embedded_mongo.h`), the error handling here should be fine.